### PR TITLE
Fix TypeError when Save a User

### DIFF
--- a/src/Users/Controllers/UserController.php
+++ b/src/Users/Controllers/UserController.php
@@ -201,7 +201,7 @@ class UserController extends AdminController
         }
 
         // Save the user's groups
-        $user->syncGroups($this->request->getPost('groups') ?? []);
+        $user->syncGroups(...($this->request->getPost('groups') ?? []));
 
         // Save the user's meta fields
         $user->syncMeta($this->request->getPost('meta') ?? []);
@@ -386,7 +386,7 @@ class UserController extends AdminController
             return redirect()->back()->with('error', lang('Bonfire.resourceNotFound', ['user']));
         }
 
-        $user->syncPermissions($this->request->getPost('permissions') ?? []);
+        $user->syncPermissions(...($this->request->getPost('permissions') ?? []));
 
         return redirect()->back()->with('message', lang('Bonfire.resourceSaved', ['permissions']));
     }


### PR DESCRIPTION
Argument 1 passed to `CodeIgniter\Shield\Entities\User::syncGroups()` must be of the type string, array given
called in `\vendor\lonnieezell\bonfire\src\Users\Controllers\UserController.php` on line 204